### PR TITLE
chore: configuring renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,11 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"config:base"
+		"github>whitesource/merge-confidence:beta",
+		"config:base",
+		":preserveSemverRanges",
+		"group:allNonMajor",
+		":semanticCommitTypeAll(chore)"
 	],
-	"baseBranches": [
-		"main"
-	]
+	"baseBranches": ["main"]
 }


### PR DESCRIPTION
Extending:
- `github>whitesource/merge-confidence:beta`: Will [add badges](https://github.com/whitesource/merge-confidence#merge-confidence) to better inform reviewer
- `:preserveSemverRanges`: Will keep package ranges (ex. `package@^1.2.3` and not turn it into `package@1.2.4`)
- `group:allNonMajor`: Will group all minor patches into a single pull request
- `:semanticCommitTypeAll(chore)`: Will follow the conventional commit messages structure